### PR TITLE
Fix incorrect key polling in key calibration routine (misplaced semicolon)

### DIFF
--- a/cpanel.c
+++ b/cpanel.c
@@ -320,7 +320,7 @@ void calibratekeys (void)
     print ("\n\rPress the new key:");
     clearkeys ();
     UpdateScreen ();
-    while ((new = bioskey (1)) == 0);
+    while ((new = bioskey (1)) == 0)
       WaitVBL();
     clearkeys ();
     print ("\r                  ");


### PR DESCRIPTION
The key polling cycle in the key calibration routine has a misplaced semicolon, which prevented WaitVBL() to run on each poll (cycle).

I'm actually no expert 😬 - I've just compared the source project with the port, and had a look at the APIs involved. The calibration actually works fine either way.